### PR TITLE
Initialize Donor donations list to avoid null refs

### DIFF
--- a/BloodDonationSystem.Core/Entities/Donor.cs
+++ b/BloodDonationSystem.Core/Entities/Donor.cs
@@ -4,9 +4,8 @@ namespace BloodDonationSystem.Core.Entities;
 
 public class Donor : BaseEntity
 {
-    public Donor( string name, string email, DateTime birthDate, GenderEnum gender, double weight, BloodTypeEnum bloodType, RhFactorEnum rhFactor,Address address)
+    public Donor(string name, string email, DateTime birthDate, GenderEnum gender, double weight, BloodTypeEnum bloodType, RhFactorEnum rhFactor, Address address)
     {
-       
         Name = name;
         Email = email;
         BirthDate = birthDate;
@@ -15,10 +14,12 @@ public class Donor : BaseEntity
         BloodType = bloodType;
         RhFactor = rhFactor;
         Address = address;
+        Donations = new List<Donation>();
     }
-    
-    protected  Donor()
+
+    protected Donor()
     {
+        Donations = new List<Donation>();
     }
 
 

--- a/BloodDonationSystem.Tests/AddressTests.cs
+++ b/BloodDonationSystem.Tests/AddressTests.cs
@@ -1,0 +1,62 @@
+using Bogus;
+using BloodDonationSystem.Core.Entities;
+
+namespace BloodDonationSystem.Tests;
+
+public class AddressTests
+{
+    private readonly Faker _faker = new();
+
+    [Fact]
+    public void Constructor_ShouldSetProperties()
+    {
+        var street = _faker.Address.StreetName();
+        var city = _faker.Address.City();
+        var state = _faker.Address.State();
+        var zip = _faker.Address.ZipCode();
+        var number = _faker.Address.BuildingNumber();
+        var complement = _faker.Address.SecondaryAddress();
+        var district = _faker.Address.County();
+
+        var address = new Address(street, city, state, zip, number, complement, district);
+
+        Assert.Equal(street, address.Street);
+        Assert.Equal(city, address.City);
+        Assert.Equal(state, address.State);
+        Assert.Equal(zip, address.ZipCode);
+        Assert.Equal(number, address.Number);
+        Assert.Equal(complement, address.Complement);
+        Assert.Equal(district, address.District);
+    }
+
+    [Fact]
+    public void Update_ShouldModifyProperties()
+    {
+        var address = new Address(
+            _faker.Address.StreetName(),
+            _faker.Address.City(),
+            _faker.Address.State(),
+            _faker.Address.ZipCode(),
+            _faker.Address.BuildingNumber(),
+            _faker.Address.SecondaryAddress(),
+            _faker.Address.County());
+
+        var newStreet = _faker.Address.StreetName();
+        var newCity = _faker.Address.City();
+        var newState = _faker.Address.State();
+        var newZip = _faker.Address.ZipCode();
+        var newNumber = _faker.Address.BuildingNumber();
+        var newComplement = _faker.Address.SecondaryAddress();
+        var newDistrict = _faker.Address.County();
+
+        address.Update(newStreet, newCity, newState, newZip, newNumber, newComplement, newDistrict);
+
+        Assert.Equal(newStreet, address.Street);
+        Assert.Equal(newCity, address.City);
+        Assert.Equal(newState, address.State);
+        Assert.Equal(newZip, address.ZipCode);
+        Assert.Equal(newNumber, address.Number);
+        Assert.Equal(newComplement, address.Complement);
+        Assert.Equal(newDistrict, address.District);
+    }
+}

--- a/BloodDonationSystem.Tests/BaseEntityTests.cs
+++ b/BloodDonationSystem.Tests/BaseEntityTests.cs
@@ -1,0 +1,26 @@
+using BloodDonationSystem.Core.Entities;
+
+namespace BloodDonationSystem.Tests;
+
+public class BaseEntityTests
+{
+    private class TestEntity : BaseEntity { }
+
+    [Fact]
+    public void Constructor_ShouldInitializeDefaults()
+    {
+        var entity = new TestEntity();
+
+        Assert.NotEqual(default, entity.Id);
+        Assert.False(entity.IsDeleted);
+        Assert.True(entity.CreatedAt <= DateTime.Now);
+    }
+
+    [Fact]
+    public void SetAsDeleted_ShouldMarkEntityDeleted()
+    {
+        var entity = new TestEntity();
+        entity.SetAsDeleted();
+        Assert.True(entity.IsDeleted);
+    }
+}

--- a/BloodDonationSystem.Tests/BloodDonationSystem.Tests.csproj
+++ b/BloodDonationSystem.Tests/BloodDonationSystem.Tests.csproj
@@ -10,14 +10,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+        <PackageReference Include="Bogus" Version="35.0.1" />
+        <PackageReference Include="coverlet.collector" Version="6.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <ProjectReference Include="..\BloodDonationSystem.Core\BloodDonationSystem.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
     </ItemGroup>
 
 </Project>

--- a/BloodDonationSystem.Tests/BloodStockTests.cs
+++ b/BloodDonationSystem.Tests/BloodStockTests.cs
@@ -1,0 +1,24 @@
+using Bogus;
+using BloodDonationSystem.Core.Entities;
+using BloodDonationSystem.Core.Enum;
+
+namespace BloodDonationSystem.Tests;
+
+public class BloodStockTests
+{
+    private readonly Faker _faker = new();
+
+    [Fact]
+    public void Constructor_ShouldSetProperties()
+    {
+        var bloodType = _faker.PickRandom<BloodTypeEnum>();
+        var rhFactor = _faker.PickRandom<RhFactorEnum>();
+        var quantity = _faker.Random.Int(100, 1000);
+
+        var stock = new BloodStock(bloodType, rhFactor, quantity);
+
+        Assert.Equal(bloodType, stock.BloodType);
+        Assert.Equal(rhFactor, stock.RhFactor);
+        Assert.Equal(quantity, stock.QuantityMl);
+    }
+}

--- a/BloodDonationSystem.Tests/DonationTests.cs
+++ b/BloodDonationSystem.Tests/DonationTests.cs
@@ -1,0 +1,23 @@
+using Bogus;
+using BloodDonationSystem.Core.Entities;
+
+namespace BloodDonationSystem.Tests;
+
+public class DonationTests
+{
+    private readonly Faker _faker = new();
+
+    [Fact]
+    public void Constructor_ShouldSetProperties()
+    {
+        var donorId = Guid.NewGuid();
+        var date = _faker.Date.Recent();
+        var quantity = _faker.Random.Int(100, 500);
+
+        var donation = new Donation(donorId, date, quantity);
+
+        Assert.Equal(donorId, donation.DonorId);
+        Assert.Equal(date, donation.DateDonation);
+        Assert.Equal(quantity, donation.QuantityMl);
+    }
+}

--- a/BloodDonationSystem.Tests/DonorTests.cs
+++ b/BloodDonationSystem.Tests/DonorTests.cs
@@ -1,0 +1,67 @@
+using Bogus;
+using BloodDonationSystem.Core.Entities;
+using BloodDonationSystem.Core.Enum;
+using System.Linq;
+
+namespace BloodDonationSystem.Tests;
+
+public class DonorTests
+{
+    private static readonly Faker Faker = new();
+
+    private Donor CreateDonor()
+    {
+        var address = new Address(
+            Faker.Address.StreetName(),
+            Faker.Address.City(),
+            Faker.Address.State(),
+            Faker.Address.ZipCode(),
+            Faker.Address.BuildingNumber(),
+            Faker.Address.SecondaryAddress(),
+            Faker.Address.County());
+
+        return new Donor(
+            Faker.Person.FullName,
+            Faker.Internet.Email(),
+            Faker.Date.Past(30, DateTime.Now.AddYears(-18)),
+            Faker.PickRandom<GenderEnum>(),
+            Faker.Random.Double(50, 100),
+            Faker.PickRandom<BloodTypeEnum>(),
+            Faker.PickRandom<RhFactorEnum>(),
+            address);
+    }
+
+    [Fact]
+    public void Constructor_ShouldInitializeEmptyDonationsList()
+    {
+        var donor = CreateDonor();
+
+        Assert.NotNull(donor.Donations);
+        Assert.Empty(donor.Donations);
+    }
+
+    [Fact]
+    public void Update_ShouldChangeNameAndEmail()
+    {
+        var donor = CreateDonor();
+        var newName = Faker.Person.FullName;
+        var newEmail = Faker.Internet.Email();
+
+        donor.Update(newName, newEmail);
+
+        Assert.Equal(newName, donor.Name);
+        Assert.Equal(newEmail, donor.Email);
+    }
+
+    [Fact]
+    public void AddingDonation_ShouldIncreaseDonationCount()
+    {
+        var donor = CreateDonor();
+        var donation = new Donation(donor.Id, Faker.Date.Recent(), Faker.Random.Int(100, 500));
+
+        donor.Donations.Add(donation);
+
+        Assert.Single(donor.Donations);
+        Assert.Equal(donor.Id, donor.Donations.First().DonorId);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `Donor` initializes its `Donations` list in both constructors
- add unit test confirming `Donor` starts with empty donation list
- reference core project from tests
- add Bogus-based tests covering core entities

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68910e28b8108329b228a4029a75f5d8