### PR TITLE
refactor: use unit of work in repositories and commands

### DIFF
--- a/BloodDonationSystem.Application/Commands/DonationsCommand/Delete/DeleteDonationCommandHandler.cs
+++ b/BloodDonationSystem.Application/Commands/DonationsCommand/Delete/DeleteDonationCommandHandler.cs
@@ -6,23 +6,24 @@ namespace BloodDonationSystem.Application.Commands.DonationsCommand.Delete;
 
 public class DeleteDonationCommandHandler : IRequestHandler<DeleteDonationCommand, ResultViewModel>
 {
-    private readonly IDonationRepository _donationRepository;
+    private readonly IUnitOfWork _unitOfWork;
 
-    public DeleteDonationCommandHandler(IDonationRepository donationRepository)
+    public DeleteDonationCommandHandler(IUnitOfWork unitOfWork)
     {
-        _donationRepository = donationRepository;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task<ResultViewModel> Handle(DeleteDonationCommand request, CancellationToken cancellationToken)
     {
-        var donation = await _donationRepository.GetById(request.Id);
+        var donation = await _unitOfWork.Donations.GetById(request.Id);
         if (donation == null)
         {
             return ResultViewModel.Error("Donation not found.");
         }
 
-        await _donationRepository.Delete(donation.Id);
-        
+        await _unitOfWork.Donations.Delete(donation.Id);
+        await _unitOfWork.CompleteAsync();
+
         return ResultViewModel.Success();
     }
 }

--- a/BloodDonationSystem.Application/Commands/DonorsCommand/Delete/DeleteDonorCommandHandler.cs
+++ b/BloodDonationSystem.Application/Commands/DonorsCommand/Delete/DeleteDonorCommandHandler.cs
@@ -6,22 +6,23 @@ namespace BloodDonationSystem.Application.Commands.DonorsCommand.Delete;
 
 public class DeleteDonorCommandHandler : IRequestHandler<DeleteDonorCommand, ResultViewModel>
 {
-    private readonly IDonorRepository _donorRepository;
+    private readonly IUnitOfWork _unitOfWork;
 
-    public DeleteDonorCommandHandler(IDonorRepository donorRepository)
+    public DeleteDonorCommandHandler(IUnitOfWork unitOfWork)
     {
-        _donorRepository = donorRepository;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task<ResultViewModel> Handle(DeleteDonorCommand request, CancellationToken cancellationToken)
     {
-        var donor= await _donorRepository.GetDonorByEmail(request.Email);   
+        var donor= await _unitOfWork.Donors.GetDonorByEmail(request.Email);
         if (donor == null)
         {
             return ResultViewModel.Error("Doador não encontrado");
         }
-        
-        await _donorRepository.Delete(donor.Id);
+
+        await _unitOfWork.Donors.Delete(donor.Id);
+        await _unitOfWork.CompleteAsync();
        return ResultViewModel.Success();
     }
 }

--- a/BloodDonationSystem.Application/Commands/DonorsCommand/Insert/CreateDonorHandler.cs
+++ b/BloodDonationSystem.Application/Commands/DonorsCommand/Insert/CreateDonorHandler.cs
@@ -9,12 +9,12 @@ namespace BloodDonationSystem.Application.Commands.DonorsCommand.Insert;
 
 public class CreateDonorHandler : IRequestHandler<CreateDonorCommand, ResultViewModel<Guid>>
 {
-    private readonly IDonorRepository _donorRepository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly IViaCepService _viaCepService;
 
-    public CreateDonorHandler(IDonorRepository donorRepository, IViaCepService viaCepService)
+    public CreateDonorHandler(IUnitOfWork unitOfWork, IViaCepService viaCepService)
     {
-        _donorRepository = donorRepository;
+        _unitOfWork = unitOfWork;
         _viaCepService = viaCepService;
     }
 
@@ -33,7 +33,8 @@ public class CreateDonorHandler : IRequestHandler<CreateDonorCommand, ResultView
         );
      
         var donor = request.ToEntity(address);
-        await _donorRepository.Add(donor);
+        await _unitOfWork.Donors.Add(donor);
+        await _unitOfWork.CompleteAsync();
         return ResultViewModel<Guid>.Success(donor.Id);
     }
 }

--- a/BloodDonationSystem.Application/Commands/DonorsCommand/Put/DonorPutCommandHandler.cs
+++ b/BloodDonationSystem.Application/Commands/DonorsCommand/Put/DonorPutCommandHandler.cs
@@ -8,19 +8,19 @@ namespace BloodDonationSystem.Application.Commands.DonorsCommand.Put;
 public class DonorPutCommandHandler : IRequestHandler<DonorPutCommand, ResultViewModel>
 {
 
-    private readonly IDonorRepository _donor;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly IViaCepService _viaCepService;
 
-    public DonorPutCommandHandler(IDonorRepository donor, IViaCepService viaCepService)
+    public DonorPutCommandHandler(IUnitOfWork unitOfWork, IViaCepService viaCepService)
     {
-        _donor = donor;
+        _unitOfWork = unitOfWork;
         _viaCepService = viaCepService;
     }
 
 
     public async Task<ResultViewModel> Handle(DonorPutCommand request, CancellationToken cancellationToken)
     {
-        var donor = await _donor.GetDonorByEmail(request.Email);
+        var donor = await _unitOfWork.Donors.GetDonorByEmail(request.Email);
         if (donor == null)
         {
             return ResultViewModel.Error("Doador não encontrado");
@@ -48,7 +48,8 @@ public class DonorPutCommandHandler : IRequestHandler<DonorPutCommand, ResultVie
 
             );
         }
-        await _donor.Update(donor);
+        await _unitOfWork.Donors.Update(donor);
+        await _unitOfWork.CompleteAsync();
         return ResultViewModel.Success();
     }
 

--- a/BloodDonationSystem.Infrastructure/Repositories/BloodStockRepository.cs
+++ b/BloodDonationSystem.Infrastructure/Repositories/BloodStockRepository.cs
@@ -18,14 +18,6 @@ public class BloodStockRepository : IBloodStockRepository
         _context = context;
     }
 
-    
-    public async Task Add(BloodStock bloodStock)
-    {
-        await _context.BloodStocks.AddAsync(bloodStock);
-    
-    }
-
-
     public async Task<List<BloodStock>> GetAllAsync()
     {
         var bloodStocks = await _context.BloodStocks

--- a/BloodDonationSystem.Infrastructure/Repositories/DonationRepository.cs
+++ b/BloodDonationSystem.Infrastructure/Repositories/DonationRepository.cs
@@ -53,9 +53,7 @@ public class DonationRepository : IDonationRepository
     public async Task Delete(Guid id)
     {
         var donation = await GetById(id);
-            donation.SetAsDeleted();
-            await _context.SaveChangesAsync();
-        
+        donation.SetAsDeleted();
     }
 
     public async Task<Donation?> GetLastByDonorIdAsync(Guid donorId)

--- a/BloodDonationSystem.Infrastructure/Repositories/DonorRepository.cs
+++ b/BloodDonationSystem.Infrastructure/Repositories/DonorRepository.cs
@@ -51,21 +51,17 @@ public class DonorRepository : IDonorRepository
     public async Task Add(Donor donor)
     {
         await _context.Donors.AddAsync(donor);
-        await _context.SaveChangesAsync(); 
-        
     }
 
-    public async Task Update(Donor donor)
+    public Task Update(Donor donor)
     {
         _context.Donors.Update(donor);
-        await _context.SaveChangesAsync();
+        return Task.CompletedTask;
     }
 
     public async Task Delete(Guid id)
     {
         var donor = await GetById(id);
         donor.SetAsDeleted();
-            await _context.SaveChangesAsync();
-        
     }
 }


### PR DESCRIPTION
## Summary
- remove SaveChanges from repositories and rely on UnitOfWork
- update donor and donation command handlers to commit via UnitOfWork

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6893b04ad8308329aaa1bb44aa62f771